### PR TITLE
Show elements only if they are bounded by the parent scroll area

### DIFF
--- a/ViMac-Swift/AppDelegate.swift
+++ b/ViMac-Swift/AppDelegate.swift
@@ -260,13 +260,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         self.resizeOverlayWindow()
 
-        let elementsOptional = Utils.traverseUIElementForPressables(rootElement: applicationWindow)
+        let elements = Utils.traverseUIElementForPressables(rootElement: applicationWindow)
         let menuBarItems = Utils.traverseForMenuBarItems(windowElement: applicationWindow)
-        guard let elements = elementsOptional else {
-            print("traversal failed")
-            self.hideOverlays()
-            return
-        }
         
         var allElements = elements + menuBarItems
 


### PR DESCRIPTION
Previous implementation was to bound by window frame which doesn't work well if the scroll area is not the height of the window.