### PR TITLE
Show hint if element's frame intersect with scroll area frame

### DIFF
--- a/ViMac-Swift/Utils.swift
+++ b/ViMac-Swift/Utils.swift
@@ -138,15 +138,18 @@ class Utils: NSObject {
 
             // append to allowed elements list if
             // 1. element's role is not blacklisted
-            // 2. element does not have a parent scroll area, but if it does it must be in it's frame
+            // 2. element does not have a parent scroll area, but if it does both frames must intersect
             if let position = positionOptional,
+                let size = sizeOptional,
                 let role = roleOptional {
+                let frame = NSRect(origin: position, size: size)
                 let blacklistedRoles = ["AXUnknown", "AXToolbar", "AXCell", "AXWindow", "AXScrollArea", "AXSplitter", "AXList"]
+                
                 //let isGroupRole = role.hasSuffix("Group")
                 let isBlacklisted = blacklistedRoles.contains(role)
                 if (!isBlacklisted) {
                     if let parentScrollAreaFrame = parentScrollAreaFrame {
-                        if parentScrollAreaFrame.contains(position) {
+                        if parentScrollAreaFrame.intersects(frame) {
                             elements.append(element)
                         }
                     } else {


### PR DESCRIPTION
In safari, navbar CSS may be poorly done (Reddit) such that navbar elements's origin does not lie in the scroll area frame despite the fact that navbars are sticky. Expect hints to start showing outside outside the scroll area for elements that are super tall.