### PR TITLE
Always enter normal mode when shortcut is pressed

### DIFF
--- a/ViMac-Swift/AppDelegate.swift
+++ b/ViMac-Swift/AppDelegate.swift
@@ -161,13 +161,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             })
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: { window in
-                let isOverlayEmpty = self.overlayWindowController.window?.contentView?.subviews.count == 0
                 self.hideOverlays()
-                
-                if !isOverlayEmpty {
-                    return
-                }
-                
                 self.setNormalMode()
             })
         )


### PR DESCRIPTION
Current implementation toggles the mode, which can be annoying when you perform a "sh" command and want to execute another command because you have to hit the shortcut once to hide scroll mode and then again to activate normal mode.