### PR TITLE
Use getMultipleAttributes instead of fetching attributes separately

### DIFF
--- a/ViMac-Swift/Utils.swift
+++ b/ViMac-Swift/Utils.swift
@@ -88,7 +88,7 @@ class Utils: NSObject {
     static func getUIElementChildrenRecursive(element: UIElement, parentScrollAreaFrame: NSRect?) -> Observable<UIElement> {
         return getAttributes(element: element)
             .flatMap({ attributes -> Observable<UIElement> in
-                let (roleOptional, positionOptional, sizeOptional) = attributes
+                let (roleOptional, positionOptional, sizeOptional, children) = attributes
 
                 var newScrollAreaFrame: NSRect? = nil
                 var isScrollArea = false
@@ -146,7 +146,7 @@ class Utils: NSObject {
                 
                 let psaf = isScrollArea ? newScrollAreaFrame : parentScrollAreaFrame
                 
-                return getChildren(element: element)
+                return Observable.just(children)
                     .flatMap({ children -> Observable<UIElement> in
                         if children.count <= 0 {
                             return Observable.just(element)
@@ -162,8 +162,8 @@ class Utils: NSObject {
             })
     }
     
-    static func getAttributes(element: UIElement) -> Observable<(String?, NSPoint?, NSSize?)> {
-        return getMultipleElementAttribute(element: element, attributes: [.role, .position, .size])
+    static func getAttributes(element: UIElement) -> Observable<(String?, NSPoint?, NSSize?, [UIElement])> {
+        return getMultipleElementAttribute(element: element, attributes: [.role, .position, .size, .children])
             .map({ valuesOptional in
                 guard let values = valuesOptional else {
                     return nil
@@ -172,7 +172,8 @@ class Utils: NSObject {
                     let role = values[0] as! String?
                     let position = values[1] as! NSPoint?
                     let size = values[2] as! NSSize?
-                    return (role, position, size)
+                    let children = (values[3] as! [AXUIElement]? ?? []).map({ UIElement($0) })
+                    return (role, position, size, children)
                 } catch {
 
                 }


### PR DESCRIPTION
Seems to improve performance. Also prevents reader-writer issue when we eventually add a attribute cache because the attributes of an element will always be fetched and store in a shared dictionary on the same thread.

Old:

```
0.34694600105285645
0.19333696365356445
0.21584999561309814
0.21444594860076904
0.20796597003936768
0.19141793251037598
0.2034139633178711
0.212691068649292
0.1947779655456543
0.19003701210021973
0.18699896335601807
0.20676302909851074
0.20545494556427002
```

New:

```
0.18296301364898682
0.18613207340240479
0.1781989336013794
0.17795097827911377
0.1754239797592163
0.1797410249710083
0.19353699684143066
0.1839669942855835
0.17483103275299072
0.17714107036590576
0.17557299137115479
0.17940199375152588
0.17303097248077393
0.18873000144958496
0.2055039405822754
0.18162500858306885

0.3661329746246338
0.18158090114593506
0.18380999565124512
0.19335103034973145
0.189628005027771
0.1911560297012329
0.18830597400665283
0.1860640048980713
0.18286490440368652
0.18332898616790771
0.17956602573394775
0.18453001976013184
0.18569695949554443
0.18004000186920166
0.18304598331451416
0.22269892692565918
0.17691802978515625
```