### PR TITLE
Fix hint positioning with multiple displays

### DIFF
--- a/ViMac-Swift/Utils.swift
+++ b/ViMac-Swift/Utils.swift
@@ -27,9 +27,7 @@ class Utils: NSObject {
     // but the coordinate system in macOS starts from bottom-left.
     // https://developer.apple.com/documentation/applicationservices/kaxpositionattribute?language=objc
     static func toOrigin(point: CGPoint, size: CGSize) -> CGPoint {
-        // cannot use NSScreen.main because the height of the global coordinate system can be larger
-        // see: https://stackoverflow.com/a/45289010/10390454
-        let screenHeight = NSScreen.screens.map { $0.frame.origin.y + $0.frame.height }.max()!
+        let screenHeight = NSScreen.screens.first!.frame.height
         return CGPoint(x: point.x, y: screenHeight - size.height - point.y)
     }
     


### PR DESCRIPTION
I have no clue how this works or why the previous `toOrigin` implementation came about.