### PR TITLE
Show hints for AXRows without actions

### DIFF
--- a/ViMac-Swift/ViewControllers/HintModeViewController.swift
+++ b/ViMac-Swift/ViewControllers/HintModeViewController.swift
@@ -155,8 +155,10 @@ class HintModeViewController: ModeViewController, NSTextFieldDelegate {
                 .observeOn(MainScheduler.instance)
                 .subscribe(
                 onSuccess: { [weak self] elements in
-                    self?.onElementTraversalComplete(elements: elements.filter({
-                        ((try? $0.actionsAsStrings().count) ?? 0) > 0
+                    self?.onElementTraversalComplete(elements: elements.filter({ element in
+                        let actionCount = (try? element.actionsAsStrings().count) ?? 0
+                        let role = try? element.role()
+                        return actionCount > 0 || role == Role.row
                     }))
                 }, onError: { error in
                     print(error)


### PR DESCRIPTION
Unfortunately checking for no. of actions > 0 is not enough :(. Even some native Mac apps have clickable row elements without any actions.

This PR will show hints for AXRows without actions, which results in more hint overlaps, but I think its a worthy tradeoff since Vimac can be used in more cases.