### PR TITLE
Fix force keyboard layout not reverting when exiting mode

### DIFF
--- a/ViMac-Swift/InputSourceManager.swift
+++ b/ViMac-Swift/InputSourceManager.swift
@@ -56,25 +56,6 @@ class InputSource: Equatable {
 
     func select() {
         TISSelectInputSource(tisInputSource)
-        
-        
-        if !isCJKV {
-            // employ same logic as the CJKV case below
-            let nonCJKVAndNonTargetSource = InputSourceManager.inputSources.first(where: { $0.id != self.id && !$0.isCJKV })
-            if let x = nonCJKVAndNonTargetSource, let selectPreviousShortcut = InputSourceManager.getSelectPreviousShortcut() {
-                TISSelectInputSource(x.tisInputSource)
-                InputSourceManager.selectPrevious(shortcut: selectPreviousShortcut)
-            }
-        }
-        
-        if isCJKV, let selectPreviousShortcut = InputSourceManager.getSelectPreviousShortcut() {
-            // Workaround for TIS CJKV layout bug:
-            // when switching to CJKV, select nonCJKV input first and then switch back (by emitting the Select the previous input source shortcut)
-            if let nonCJKV = InputSourceManager.nonCJKVSource() {
-                TISSelectInputSource(nonCJKV.tisInputSource)
-                InputSourceManager.selectPrevious(shortcut: selectPreviousShortcut)
-            }
-        }
     }
 }
 

--- a/ViMac-Swift/ModeCoordinator.swift
+++ b/ViMac-Swift/ModeCoordinator.swift
@@ -32,15 +32,15 @@ class ModeCoordinator : Coordinator {
     }
     
     func exitMode() {
+        if self.forceKBLayout != nil {
+            self.priorKBLayout?.select()
+        }
+        
         // if there is an active mode, remove its view controller and revert keyboard layout
         if let vc = self.windowController.window?.contentViewController {
+
             vc.view.removeFromSuperview()
             self.windowController.window?.contentViewController = nil
-            
-            // only reverse keyboard layout if user is forcing layout.
-            if self.forceKBLayout != nil {
-                self.priorKBLayout?.select()
-            }
         }
 
         self.windowController.close()


### PR DESCRIPTION
From what I read, TISSelectInputSource only works consistently and correctly when you own the active text area. Hence, reverting input source after removing the view controller doesn't work correctly.