### PR TITLE
Fixed Notification Center alert support for other languages

### DIFF
--- a/ViMac-Swift/Services/QueryNotificationCenterItemsService.swift
+++ b/ViMac-Swift/Services/QueryNotificationCenterItemsService.swift
@@ -12,7 +12,7 @@ import AXSwift
 class QueryNotificationCenterItemsService {
     func perform() throws -> [Element]? {
         let notificationAppOptional = NSWorkspace.shared.runningApplications
-            .first(where: { $0.localizedName == "Notification Centre" })
+            .first(where: { $0.bundleIdentifier == "com.apple.notificationcenterui" })
         guard let notificationApp = notificationAppOptional,
             let notificationAppUIElement = Application(notificationApp) else {
             return nil


### PR DESCRIPTION
Changed to use `bundleIdentifier` rather than `localizedName`.