### PR TITLE
Use dialogs over red/black text field background color to indicate invalid input

### DIFF
--- a/ViMac-Swift/Windows/Preferences/HintModePreferenceViewController.swift
+++ b/ViMac-Swift/Windows/Preferences/HintModePreferenceViewController.swift
@@ -82,7 +82,7 @@ extension HintModePreferenceViewController {
             let value = textField.stringValue
             let isValid = UserPreferences.HintMode.CustomCharactersProperty.isValid(value: value)
             
-            if !isValid {
+            if value.count > 0 && !isValid {
                 showInvalidValueDialog(value)
             }
         }
@@ -91,7 +91,7 @@ extension HintModePreferenceViewController {
             let value = textField.stringValue
             let isValid = UserPreferences.HintMode.TextSizeProperty.isValid(value: value)
             
-            if !isValid {
+            if value.count > 0 && !isValid {
                 showInvalidValueDialog(value)
             }
         }

--- a/ViMac-Swift/Windows/Preferences/HintModePreferenceViewController.swift
+++ b/ViMac-Swift/Windows/Preferences/HintModePreferenceViewController.swift
@@ -3,7 +3,7 @@ import RxCocoa
 import RxSwift
 import Preferences
 
-final class HintModePreferenceViewController: NSViewController, PreferencePane {
+final class HintModePreferenceViewController: NSViewController, NSTextFieldDelegate, PreferencePane {
     let preferencePaneIdentifier = PreferencePane.Identifier.hintMode
     let preferencePaneTitle = "Hint Mode"
     
@@ -16,9 +16,11 @@ final class HintModePreferenceViewController: NSViewController, PreferencePane {
     
     let compositeDisposable = CompositeDisposable()
     
-    lazy var customCharactersViewObservable = customCharactersView.rx.text.map({ $0! })
-    lazy var customCharactersViewValidityChangeObservable = customCharactersViewObservable.distinctUntilChanged()
-    lazy var textSizeObservable = textSizeView.rx.text.map({ $0! })
+    let customCharactersViewSubject = PublishSubject<String>()
+    lazy var customCharactersViewObservable = customCharactersViewSubject.asObserver()
+    
+    let textSizeSubject = PublishSubject<String>()
+    lazy var textSizeObservable = textSizeSubject.asObserver()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,8 +32,10 @@ final class HintModePreferenceViewController: NSViewController, PreferencePane {
         textSizeView.stringValue = UserPreferences.HintMode.TextSizeProperty.readUnvalidated() ?? ""
         
         compositeDisposable.insert(observeCustomCharactersChange())
-        compositeDisposable.insert(observeCustomCharactersValidityChange())
         compositeDisposable.insert(observeTextSizeChange())
+
+        textSizeView.delegate = self
+        customCharactersView.delegate = self
     }
 
     deinit {
@@ -39,45 +43,66 @@ final class HintModePreferenceViewController: NSViewController, PreferencePane {
     }
     
     func observeCustomCharactersChange() -> Disposable {
-        return customCharactersViewObservable.bind(onNext: { [weak self] characters in
+        return customCharactersViewObservable.bind(onNext: { characters in
             UserPreferences.HintMode.CustomCharactersProperty.save(value: characters)
         })
     }
     
-    func observeCustomCharactersValidityChange() -> Disposable {
-        return customCharactersViewValidityChangeObservable.bind(onNext: { [weak self] characters in
-            let isValid = UserPreferences.HintMode.CustomCharactersProperty.isValid(value: characters)
-            
-            if !isValid {
-                self?.changeCustomTextViewBackgroundColor(textField: self!.customCharactersView, color: NSColor.init(calibratedRed: 132/255, green: 46/255, blue: 48/255, alpha: 1))
-                return
-            }
-            
-            self?.changeCustomTextViewBackgroundColor(textField: self!.customCharactersView, color: NSColor.black)
-        })
-    }
-    
     func observeTextSizeChange() -> Disposable {
-        return textSizeObservable.bind(onNext: { [weak self] textSize in
+        return textSizeObservable.bind(onNext: { textSize in
             UserPreferences.HintMode.TextSizeProperty.save(value: textSize)
-
-            let isValid = UserPreferences.HintMode.TextSizeProperty.isValid(value: textSize)
-
-            if !isValid {
-                self?.changeCustomTextViewBackgroundColor(textField: self!.textSizeView, color: NSColor.init(calibratedRed: 132/255, green: 46/255, blue: 48/255, alpha: 1))
-                return
-            }
-            
-            self?.changeCustomTextViewBackgroundColor(textField: self!.textSizeView, color: NSColor.black)
         })
     }
+}
+
+extension HintModePreferenceViewController {
     
-    func changeCustomTextViewBackgroundColor(textField: NSTextField, color: NSColor) {
-        textField.backgroundColor = color
+    func controlTextDidChange(_ notification: Notification) {
+        guard let textField = notification.object as? NSTextField else {
+            return
+        }
         
-        // setting backgroundColor does not work properly after the first time until text field is out of focus.
-        // see: https://stackoverflow.com/a/16489472/10390454
-        textField.isEditable = false
-        textField.isEditable = true
+        if textField == customCharactersView {
+            customCharactersViewSubject.onNext(textField.stringValue)
+        }
+        
+        if textField == textSizeView {
+            textSizeSubject.onNext(textField.stringValue)
+        }
+    }
+}
+
+extension HintModePreferenceViewController {
+    func controlTextDidEndEditing(_ notification: Notification) {
+        guard let textField = notification.object as? NSTextField else {
+            return
+        }
+        
+        if textField == customCharactersView {
+            let value = textField.stringValue
+            let isValid = UserPreferences.HintMode.CustomCharactersProperty.isValid(value: value)
+            
+            if !isValid {
+                showInvalidValueDialog(value)
+            }
+        }
+        
+        if textField == textSizeView {
+            let value = textField.stringValue
+            let isValid = UserPreferences.HintMode.TextSizeProperty.isValid(value: value)
+            
+            if !isValid {
+                showInvalidValueDialog(value)
+            }
+        }
+    }
+    
+    private func showInvalidValueDialog(_ value: String) {
+        let alert = NSAlert()
+        alert.messageText = "The value \"\(value)\" is invalid."
+        alert.informativeText = "Please provide a valid value."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }

--- a/ViMac-Swift/Windows/Preferences/ScrollModePreferenceViewController.swift
+++ b/ViMac-Swift/Windows/Preferences/ScrollModePreferenceViewController.swift
@@ -104,7 +104,7 @@ extension ScrollModePreferenceViewController {
             let value = textField.stringValue
             let isValid = isScrollKeysValid(keys: value)
             
-            if !isValid {
+            if value.count > 0 && !isValid {
                 showInvalidValueDialog(value)
             }
         }


### PR DESCRIPTION
Closes #216,
Closes #194 
Closes #244 

Previously a red background in a text field was used to indicate invalid input for preferences.

This was confusing for some users and had terrible contrast in light mode.

From the macOS HIG:

>  Perform field validation. Let the user know if they’ve entered an invalid value. If the only legitimate value for a field is a string of digits, for example, your app should alert the user if they’ve entered characters other than digits. In most cases, the best time to check the data is when the user clicks outside the field or presses the Return, Enter, or Tab key.

Now, validation occurs only after the user exits the field (instead of when they edit it), and the following prompt is shown:

<img width="576" alt="Screenshot 2020-10-13 at 9 01 10 PM" src="https://user-images.githubusercontent.com/34204380/95863822-3a0bb280-0d97-11eb-81c7-1400ee5726d9.png">
