### PR TITLE
Remove whitelist actions

### DIFF
--- a/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
@@ -65,7 +65,13 @@ class FlattenElementTreeNode {
             .map { flatten($0) }
             .reduce(0, +)
         
-        let isActionable = node.root.actions.count > 0
+        let ignoredActions: Set = [
+            "AXShowMenu",
+            "AXScrollToVisible",
+        ]
+        let actions = Set(node.root.actions).subtracting(ignoredActions)
+        
+        let isActionable = actions.count > 0
         let isRowWithoutActionableChildren = childrenHintableElements == 0 && node.root.role == "AXRow"
         let isHintable = isActionable || isRowWithoutActionableChildren
         

--- a/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
@@ -49,7 +49,6 @@ class QueryWindowService {
 class FlattenElementTreeNode {
     let root: ElementTreeNode
     var result: [Element] = []
-    let whitelistedActions = Set(UserPreferences.HintMode.ActionsProperty.read())
 
     init(_ root: ElementTreeNode) {
         self.root = root
@@ -66,8 +65,9 @@ class FlattenElementTreeNode {
             .map { flatten($0) }
             .reduce(0, +)
         
-        let containsWhitelistedAction = Set(node.root.actions).intersection(whitelistedActions).count > 0
-        let isHintable = containsWhitelistedAction || (childrenHintableElements == 0 && node.root.role == "AXRow")
+        let isActionable = node.root.actions.count > 0
+        let isRowWithoutActionableChildren = childrenHintableElements == 0 && node.root.role == "AXRow"
+        let isHintable = isActionable || isRowWithoutActionableChildren
         
         if isHintable {
             result.append(node.root)

--- a/ViMac-Swift/UserPreferences.swift
+++ b/ViMac-Swift/UserPreferences.swift
@@ -68,26 +68,6 @@ struct UserPreferences {
                 return Float(read())!
             }
         }
-        
-        class ActionsProperty : PreferenceProperty {
-            typealias T = [String]
-            
-            static var key = "HintActions"
-            static var defaultValue = [
-                "AXPress",
-                "AXIncrement",
-                "AXDecrement",
-                "AXConfirm",
-                "AXPick",
-                "AXCancel",
-                "AXRaise",
-                "AXOpen"
-            ]
-            
-            static func isValid(value: [String]) -> Bool {
-                return true
-            }
-        }
     }
     
     struct ScrollMode {

--- a/ViMac-Swift/Windows/Preferences/HintModePreferenceViewController.swift
+++ b/ViMac-Swift/Windows/Preferences/HintModePreferenceViewController.swift
@@ -14,8 +14,6 @@ final class HintModePreferenceViewController: NSViewController, PreferencePane {
     @IBOutlet weak var textSizeView: NSTextField!
     @IBOutlet weak var gridView: NSGridView!
     
-    var actionCheckboxes: [NSButton]?
-    
     let compositeDisposable = CompositeDisposable()
     
     lazy var customCharactersViewObservable = customCharactersView.rx.text.map({ $0! })
@@ -34,8 +32,6 @@ final class HintModePreferenceViewController: NSViewController, PreferencePane {
         compositeDisposable.insert(observeCustomCharactersChange())
         compositeDisposable.insert(observeCustomCharactersValidityChange())
         compositeDisposable.insert(observeTextSizeChange())
-        
-        setupActions()
     }
 
     deinit {
@@ -83,54 +79,5 @@ final class HintModePreferenceViewController: NSViewController, PreferencePane {
         // see: https://stackoverflow.com/a/16489472/10390454
         textField.isEditable = false
         textField.isEditable = true
-    }
-    
-    func setupActions() {
-        let label = NSTextField.init(string: "Shown for actions:")
-        label.isEditable = false
-        label.isSelectable = false
-        label.isBezeled = false
-        label.drawsBackground = false
-
-        let actions = [
-            "AXPress",
-            "AXIncrement",
-            "AXDecrement",
-            "AXConfirm",
-            "AXPick",
-            "AXCancel",
-            "AXRaise",
-            "AXShowMenu",
-            "AXOpen"
-        ]
-        
-        let whitelistedActions = UserPreferences.HintMode.ActionsProperty.read()
-
-        let actionCheckboxes = actions.map { action -> NSButton in
-            let checkbox = NSButton.init(checkboxWithTitle: action, target: nil, action: nil)
-            checkbox.state = whitelistedActions.contains(action) ? .on : .off
-            return checkbox
-        }
-        self.actionCheckboxes = actionCheckboxes
-        
-        gridView.addRow(with: [label, actionCheckboxes.first!])
-        for checkbox in actionCheckboxes[1...actionCheckboxes.count-1] {
-            gridView.addRow(with: [NSView(), checkbox])
-        }
-        
-        for checkbox in actionCheckboxes {
-            let disposable = checkbox.rx.state.bind(onNext: { [weak self] state in
-                self?.saveActions()
-            })
-            compositeDisposable.insert(disposable)
-        }
-    }
-    
-    func saveActions() {
-        let enabledActions = actionCheckboxes!
-            .filter { $0.state == .on }
-            .map { $0.title }
-        print(enabledActions)
-        UserPreferences.HintMode.ActionsProperty.save(value: enabledActions)
     }
 }


### PR DESCRIPTION
Undo #188

Vimac determines whether a element is hintable through the action count. The whole point of #188 was to ignore certain actions (e.g. AXShowMenu). A whitelist/blacklist actions feature was in hindsight not a great solution because we have to hardcode all possible actions to Vimac.  Some users thought changing it would lead to faster performance - which is not true.

I think until we can come up with a better solution for a user to be able to declare the actions they want/don't want - I'll hardcode the behaviour of ignoring AXShowMenu and AXScrollToVisible.