### PR TITLE
Fix cursor not reappearing

### DIFF
--- a/ViMac-Swift/HideCursorGlobally.m
+++ b/ViMac-Swift/HideCursorGlobally.m
@@ -11,10 +11,6 @@
 @implementation HideCursorGlobally
 
 + (void) hide {
-    if (!CGCursorIsVisible()) {
-        return;
-    }
-    
     void CGSSetConnectionProperty(int, int, CFStringRef, CFBooleanRef);
     int _CGSDefaultConnection();
     CFStringRef propertyString;
@@ -28,10 +24,6 @@
 }
 
 + (void) unhide {
-    if (CGCursorIsVisible()) {
-        return;
-    }
-
     CGDisplayShowCursor(CGMainDisplayID());
 }
 @end


### PR DESCRIPTION
Turns out #220 introduced the very cursor issue it was trying to prevent :/. CGCursorIsVisible doesn't always return the correct state. It is also deprecated.

