### PR TITLE
Use Search Keys when querying Safari web areas.

### DIFF
--- a/ViMac-Swift/Accessibility/Element.swift
+++ b/ViMac-Swift/Accessibility/Element.swift
@@ -45,7 +45,7 @@ class ElementTreeNode {
     }
     
     func isHintable() -> Bool {
-        isActionable() || isRowWithoutActionableChildren()
+        isActionable() || isRowWithoutHintableChildren()
     }
     
     private func isActionable() -> Bool {
@@ -57,7 +57,7 @@ class ElementTreeNode {
         return actions.count > 0
     }
     
-    private func isRowWithoutActionableChildren() -> Bool {
+    private func isRowWithoutHintableChildren() -> Bool {
         hintableChildrenCount() == 0 && root.role == "AXRow"
     }
     

--- a/ViMac-Swift/Accessibility/Element.swift
+++ b/ViMac-Swift/Accessibility/Element.swift
@@ -76,6 +76,6 @@ class ElementTreeNode {
 
 class SafariWebAreaElementTreeNode : ElementTreeNode {
     override func isHintable() -> Bool {
-        return root.actions.count > 0
+        return true
     }
 }

--- a/ViMac-Swift/Accessibility/HintMode/QueryMenuBarItemsService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/QueryMenuBarItemsService.swift
@@ -10,14 +10,14 @@ import Cocoa
 import AXSwift
 
 class QueryMenuBarItemsService {
-    let applicationElement: AXUIElement
+    let app: NSRunningApplication
 
-    init(applicationElement: AXUIElement) {
-        self.applicationElement = applicationElement
+    init(app: NSRunningApplication) {
+        self.app = app
     }
     
     func perform() throws -> [Element]? {
-        let appUIElement = UIElement(applicationElement)
+        guard let appUIElement = Application(app) else { return nil }
         
         let menuBarOptional: UIElement? = try appUIElement.attribute(.menuBar)
         guard let menuBar = menuBarOptional else { return nil }

--- a/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
@@ -10,10 +10,12 @@ import Cocoa
 import AXSwift
 
 class QueryWindowService {
-    let windowElement: Element
+    let app: NSRunningApplication
+    let window: Element
     
-    init(windowElement: Element) {
-        self.windowElement = windowElement
+    init(app: NSRunningApplication, window: Element) {
+        self.app = app
+        self.window = window
     }
     
     func perform() throws -> [Element] {
@@ -21,7 +23,7 @@ class QueryWindowService {
         let childrenNodes = children?.map { child -> ElementTreeNode? in
             TraverseElementServiceFinder
                 .init(child).find()
-                .init(element: child, windowElement: windowElement, containerElement: nil).perform()
+                .init(element: child, app: app, windowElement: window, containerElement: nil).perform()
         }
         
         var elements: [Element] = []
@@ -35,7 +37,7 @@ class QueryWindowService {
     }
     
     private func getChildren() throws -> [Element]? {
-        let rawElements: [AXUIElement]? = try UIElement(windowElement.rawElement).attribute(.children)
+        let rawElements: [AXUIElement]? = try UIElement(window.rawElement).attribute(.children)
         return rawElements?
             .map { Element.initialize(rawElement: $0) }
             .compactMap({ $0 })

--- a/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
@@ -61,27 +61,14 @@ class FlattenElementTreeNode {
         return result
     }
     
-    private func flatten(_ node: ElementTreeNode) -> Int {
-        let children = node.children ?? []
-        let childrenHintableElements = children
-            .map { flatten($0) }
-            .reduce(0, +)
-        
-        let ignoredActions: Set = [
-            "AXShowMenu",
-            "AXScrollToVisible",
-        ]
-        let actions = Set(node.root.actions).subtracting(ignoredActions)
-        
-        let isActionable = actions.count > 0
-        let isRowWithoutActionableChildren = childrenHintableElements == 0 && node.root.role == "AXRow"
-        let isHintable = isActionable || isRowWithoutActionableChildren
-        
-        if isHintable {
+    private func flatten(_ node: ElementTreeNode) {
+        if node.isHintable() {
             result.append(node.root)
-            return childrenHintableElements + 1
         }
         
-        return childrenHintableElements
+        let children = node.children ?? []
+        for child in children {
+            flatten(child)
+        }
     }
 }

--- a/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/QueryWindowService.swift
@@ -22,7 +22,7 @@ class QueryWindowService {
         let children = try getChildren()
         let childrenNodes = children?.map { child -> ElementTreeNode? in
             TraverseElementServiceFinder
-                .init(child).find()
+                .init(app: app, element: child).find()
                 .init(element: child, app: app, windowElement: window, containerElement: nil).perform()
         }
         

--- a/ViMac-Swift/Accessibility/HintMode/TraverseElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseElementService.swift
@@ -9,6 +9,6 @@
 import Cocoa
 
 protocol TraverseElementService {
-    init(element: Element, windowElement: Element, containerElement: Element?)
+    init(element: Element, app: NSRunningApplication, windowElement: Element, containerElement: Element?)
     func perform() -> ElementTreeNode
 }

--- a/ViMac-Swift/Accessibility/HintMode/TraverseElementServiceFinder.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseElementServiceFinder.swift
@@ -10,14 +10,20 @@ import Cocoa
 import AXSwift
 
 class TraverseElementServiceFinder {
+    let app: NSRunningApplication
     let element: Element
     
-    init(_ element: Element) {
+    init(app: NSRunningApplication, element: Element) {
+        self.app = app
         self.element = element
     }
     
     func find() -> TraverseElementService.Type {
         if element.role == "AXWebArea" && supportsChildrenThroughSearchPredicate() {
+            if app.bundleIdentifier == "com.apple.Safari" {
+                return TraverseSafariWebAreaElementService.self
+            }
+            
             return TraverseSearchPredicateCompatibleWebAreaElementService.self
         }
         

--- a/ViMac-Swift/Accessibility/HintMode/TraverseElementServiceFinder.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseElementServiceFinder.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import AXSwift
 
 class TraverseElementServiceFinder {
     let element: Element
@@ -16,11 +17,16 @@ class TraverseElementServiceFinder {
     }
     
     func find() -> TraverseElementService.Type {
-        if element.role == "AXWebArea" {
-            return TraverseWebAreaElementService.self
+        if element.role == "AXWebArea" && supportsChildrenThroughSearchPredicate() {
+            return TraverseSearchPredicateCompatibleWebAreaElementService.self
         }
         
         return TraverseGenericElementService.self
+    }
+    
+    private func supportsChildrenThroughSearchPredicate() -> Bool {
+        let parameterizedAttrs = try? UIElement(element.rawElement).parameterizedAttributesAsStrings()
+        return parameterizedAttrs?.contains("AXUIElementsForSearchPredicate") ?? false
     }
 }
 

--- a/ViMac-Swift/Accessibility/HintMode/TraverseGenericElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseGenericElementService.swift
@@ -36,7 +36,7 @@ class TraverseGenericElementService : TraverseElementService {
     
     private func traverseElement(_ element: Element) -> ElementTreeNode? {
         TraverseElementServiceFinder
-            .init(element).find()
+            .init(app: app, element: element).find()
             .init(element: element, app: app, windowElement: windowElement, containerElement: childContainerElement).perform()
     }
     

--- a/ViMac-Swift/Accessibility/HintMode/TraverseGenericElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseGenericElementService.swift
@@ -11,13 +11,15 @@ import AXSwift
 
 class TraverseGenericElementService : TraverseElementService {
     let element: Element
+    let app: NSRunningApplication
     let windowElement: Element
     let containerElement: Element?
     
     lazy var childContainerElement = computeChildContainerElement()
     
-    required init(element: Element, windowElement: Element, containerElement: Element?) {
+    required init(element: Element, app: NSRunningApplication, windowElement: Element, containerElement: Element?) {
         self.element = element
+        self.app = app
         self.windowElement = windowElement
         self.containerElement = containerElement
     }
@@ -35,7 +37,7 @@ class TraverseGenericElementService : TraverseElementService {
     private func traverseElement(_ element: Element) -> ElementTreeNode? {
         TraverseElementServiceFinder
             .init(element).find()
-            .init(element: element, windowElement: windowElement, containerElement: childContainerElement).perform()
+            .init(element: element, app: app, windowElement: windowElement, containerElement: childContainerElement).perform()
     }
     
     private func computeChildContainerElement() -> Element? {

--- a/ViMac-Swift/Accessibility/HintMode/TraverseSafariWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSafariWebAreaElementService.swift
@@ -25,8 +25,8 @@ class TraverseSafariWebAreaElementService : TraverseElementService {
     func perform() -> ElementTreeNode {
         let recursiveChildren = try? getRecursiveChildrenThroughSearchPredicate()
         let recursiveChildrenNodes = recursiveChildren?
-            .map { ElementTreeNode(root: $0, children: nil) }
-        return ElementTreeNode(root: element, children: recursiveChildrenNodes)
+            .map { SafariWebAreaElementTreeNode(root: $0, children: nil) }
+        return SafariWebAreaElementTreeNode(root: element, children: recursiveChildrenNodes)
     }
     
     private func getRecursiveChildrenThroughSearchPredicate() throws -> [Element]? {

--- a/ViMac-Swift/Accessibility/HintMode/TraverseSafariWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSafariWebAreaElementService.swift
@@ -42,7 +42,6 @@ class TraverseSafariWebAreaElementService : TraverseElementService {
                 "AXGraphicSearchKey",
                 "AXLinkSearchKey",
                 "AXRadioGroupSearchKey",
-                "AXStaticTextSearchKey",
                 "AXTextFieldSearchKey"
             ]
         ]

--- a/ViMac-Swift/Accessibility/HintMode/TraverseSafariWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSafariWebAreaElementService.swift
@@ -1,15 +1,15 @@
 //
-//  TraverseWebAreaElementService.swift
+//  TraverseSafariWebAreaElementService.swift
 //  Vimac
 //
-//  Created by Dexter Leng on 6/9/20.
+//  Created by Dexter Leng on 19/12/20.
 //  Copyright © 2020 Dexter Leng. All rights reserved.
 //
 
 import Cocoa
 import AXSwift
 
-class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementService {
+class TraverseSafariWebAreaElementService : TraverseElementService {
     let element: Element
     let app: NSRunningApplication
     let windowElement: Element
@@ -35,7 +35,16 @@ class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementSe
             "AXImmediateDescendantsOnly": false,
             "AXResultsLimit": -1,
             "AXVisibleOnly": true,
-            "AXSearchKey": "AXAnyTypeSearchKey"
+            "AXSearchKey": [
+                "AXButtonSearchKey",
+                "AXCheckBoxSearchKey",
+                "AXControlSearchKey",
+                "AXGraphicSearchKey",
+                "AXLinkSearchKey",
+                "AXRadioGroupSearchKey",
+                "AXStaticTextSearchKey",
+                "AXTextFieldSearchKey"
+            ]
         ]
         let rawElements: [AXUIElement]? = try UIElement(element.rawElement).parameterizedAttribute("AXUIElementsForSearchPredicate", param: query)
         let elements = rawElements?
@@ -44,3 +53,4 @@ class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementSe
         return elements
     }
 }
+

--- a/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
@@ -11,7 +11,7 @@ import Cocoa
 import Cocoa
 import AXSwift
 
-class TraverseWebAreaElementService : TraverseElementService {
+class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementService {
     let element: Element
     let windowElement: Element
     let containerElement: Element?
@@ -22,20 +22,11 @@ class TraverseWebAreaElementService : TraverseElementService {
         self.containerElement = containerElement
     }
     
-    func perform() -> ElementTreeNode {
-        if !supportsChildrenThroughSearchPredicate() {
-            return TraverseGenericElementService.init(element: element, windowElement: windowElement, containerElement: containerElement).perform()
-        }
-        
+    func perform() -> ElementTreeNode {        
         let recursiveChildren = try? getRecursiveChildrenThroughSearchPredicate()
         let recursiveChildrenNodes = recursiveChildren?
             .map { ElementTreeNode(root: $0, children: nil) }
         return ElementTreeNode(root: element, children: recursiveChildrenNodes)
-    }
-    
-    private func supportsChildrenThroughSearchPredicate() -> Bool {
-        let parameterizedAttrs = try? UIElement(element.rawElement).parameterizedAttributesAsStrings()
-        return parameterizedAttrs?.contains("AXUIElementsForSearchPredicate") ?? false
     }
     
     private func getRecursiveChildrenThroughSearchPredicate() throws -> [Element]? {

--- a/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
@@ -22,7 +22,7 @@ class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementSe
         self.containerElement = containerElement
     }
     
-    func perform() -> ElementTreeNode {        
+    func perform() -> ElementTreeNode {
         let recursiveChildren = try? getRecursiveChildrenThroughSearchPredicate()
         let recursiveChildrenNodes = recursiveChildren?
             .map { ElementTreeNode(root: $0, children: nil) }

--- a/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
@@ -13,11 +13,13 @@ import AXSwift
 
 class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementService {
     let element: Element
+    let app: NSRunningApplication
     let windowElement: Element
     let containerElement: Element?
     
-    required init(element: Element, windowElement: Element, containerElement: Element?) {
+    required init(element: Element, app: NSRunningApplication, windowElement: Element, containerElement: Element?) {
         self.element = element
+        self.app = app
         self.windowElement = windowElement
         self.containerElement = containerElement
     }

--- a/ViMac-Swift/ModeCoordinator.swift
+++ b/ViMac-Swift/ModeCoordinator.swift
@@ -60,8 +60,8 @@ class ModeCoordinator : Coordinator {
     }
     
     func setHintMode() {
-        guard let applicationWindow = Utils.getCurrentApplicationWindowManually(),
-            let window = self.windowController.window else {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+            let focusedWindow = focusedWindow(app: frontmostApp) else {
             self.exitMode()
             return
         }
@@ -71,7 +71,7 @@ class ModeCoordinator : Coordinator {
             forceKBLayout.select()
         }
 
-        let vc = HintModeViewController.init(applicationWindow: applicationWindow)
+        let vc = HintModeViewController.init(app: frontmostApp, window: focusedWindow)
         self.setViewController(vc: vc)
     }
     
@@ -85,6 +85,16 @@ class ModeCoordinator : Coordinator {
             self?.forceKBLayout = inputSource
         })
         return observation
+    }
+    
+    private func focusedWindow(app: NSRunningApplication) -> Element? {
+        let axAppOptional = Application.init(app)
+        guard let axApp = axAppOptional else { return nil }
+        
+        let axWindowOptional: UIElement? = try? axApp.attribute(.focusedWindow)
+        guard let axWindow = axWindowOptional else { return nil }
+        
+        return Element.initialize(rawElement: axWindow.element)
     }
 }
 

--- a/ViMac-Swift/ViewControllers/HintModeViewController.swift
+++ b/ViMac-Swift/ViewControllers/HintModeViewController.swift
@@ -66,7 +66,7 @@ class HintModeViewController: ModeViewController, NSTextFieldDelegate {
             }
             
             let thread = Thread.init(block: {
-                let service = QueryWindowService.init(windowElement: self.window)
+                let service = QueryWindowService.init(app: self.app, window: self.window)
                 let elements = try? service.perform()
                 event(.success(elements ?? []))
             })

--- a/Vimac.xcodeproj/project.pbxproj
+++ b/Vimac.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		E28867F0235F54F2001691A5 /* Vimac.icns in Resources */ = {isa = PBXBuildFile; fileRef = E28867EF235F54F1001691A5 /* Vimac.icns */; };
 		E290EF4B24F93343004B1A83 /* QueryWindowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E290EF4A24F93342004B1A83 /* QueryWindowService.swift */; };
 		E2B3F64B24F24B9800FD5594 /* HintModeInputListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B3F64A24F24B9800FD5594 /* HintModeInputListener.swift */; };
+		E2B98A46258DF15C00A90B2F /* TraverseSafariWebAreaElementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B98A45258DF15C00A90B2F /* TraverseSafariWebAreaElementService.swift */; };
 		E2C29562234DD7F8001A38D6 /* OverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C29561234DD7F8001A38D6 /* OverlayWindowController.swift */; };
 		E2C29566234DE09C001A38D6 /* ModeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C29565234DE09C001A38D6 /* ModeCoordinator.swift */; };
 		E2C29568234DE51F001A38D6 /* ModeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C29567234DE51F001A38D6 /* ModeViewController.swift */; };
@@ -179,6 +180,7 @@
 		E28867EF235F54F1001691A5 /* Vimac.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = Vimac.icns; sourceTree = SOURCE_ROOT; };
 		E290EF4A24F93342004B1A83 /* QueryWindowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryWindowService.swift; sourceTree = "<group>"; };
 		E2B3F64A24F24B9800FD5594 /* HintModeInputListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintModeInputListener.swift; sourceTree = "<group>"; };
+		E2B98A45258DF15C00A90B2F /* TraverseSafariWebAreaElementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseSafariWebAreaElementService.swift; sourceTree = "<group>"; };
 		E2C29561234DD7F8001A38D6 /* OverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowController.swift; sourceTree = "<group>"; };
 		E2C29565234DE09C001A38D6 /* ModeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeCoordinator.swift; sourceTree = "<group>"; };
 		E2C29567234DE51F001A38D6 /* ModeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeViewController.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				E23140D52506781E004D1B96 /* QueryMenuBarItemsService.swift */,
 				E23140D725067A46004D1B96 /* QueryMenuBarExtrasService.swift */,
 				E23140D92507B2C1004D1B96 /* QueryNotificationCenterItemsService.swift */,
+				E2B98A45258DF15C00A90B2F /* TraverseSafariWebAreaElementService.swift */,
 			);
 			path = HintMode;
 			sourceTree = "<group>";
@@ -722,6 +725,7 @@
 				E26981B323C99DBB00E46217 /* WelcomeWindowController.swift in Sources */,
 				E26172242322968500E396CA /* AppDelegate.swift in Sources */,
 				E2677790256187230034B131 /* ScrollModeActiveScrollAreaViewController.swift in Sources */,
+				E2B98A46258DF15C00A90B2F /* TraverseSafariWebAreaElementService.swift in Sources */,
 				E2677780255FE0420034B131 /* QueryScrollAreasService.swift in Sources */,
 				E23140D62506781E004D1B96 /* QueryMenuBarItemsService.swift in Sources */,
 				E2F6C9AD232DE89F00F2975B /* HintView.swift in Sources */,

--- a/Vimac.xcodeproj/project.pbxproj
+++ b/Vimac.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		E270F5C52504D8DE00AD305A /* TraverseElementServiceFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270F5C42504D8DE00AD305A /* TraverseElementServiceFinder.swift */; };
 		E270F5C92504D9AE00AD305A /* TraverseGenericElementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270F5C82504D9AE00AD305A /* TraverseGenericElementService.swift */; };
 		E270F5CB2504D9DE00AD305A /* TraverseElementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270F5CA2504D9DE00AD305A /* TraverseElementService.swift */; };
-		E270F5CF2504DC4600AD305A /* TraverseWebAreaElementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270F5CE2504DC4600AD305A /* TraverseWebAreaElementService.swift */; };
+		E270F5CF2504DC4600AD305A /* TraverseSearchPredicateCompatibleWebAreaElementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E270F5CE2504DC4600AD305A /* TraverseSearchPredicateCompatibleWebAreaElementService.swift */; };
 		E27776E3240B780D00488320 /* LaunchAtLogin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E27776E2240B780D00488320 /* LaunchAtLogin.framework */; };
 		E27776E4240B780D00488320 /* LaunchAtLogin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E27776E2240B780D00488320 /* LaunchAtLogin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E27776E8240B784900488320 /* LaunchAtLogin.framework.dSYM in CopyFiles */ = {isa = PBXBuildFile; fileRef = E27776E7240B784900488320 /* LaunchAtLogin.framework.dSYM */; };
@@ -169,7 +169,7 @@
 		E270F5C42504D8DE00AD305A /* TraverseElementServiceFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseElementServiceFinder.swift; sourceTree = "<group>"; };
 		E270F5C82504D9AE00AD305A /* TraverseGenericElementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseGenericElementService.swift; sourceTree = "<group>"; };
 		E270F5CA2504D9DE00AD305A /* TraverseElementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseElementService.swift; sourceTree = "<group>"; };
-		E270F5CE2504DC4600AD305A /* TraverseWebAreaElementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseWebAreaElementService.swift; sourceTree = "<group>"; };
+		E270F5CE2504DC4600AD305A /* TraverseSearchPredicateCompatibleWebAreaElementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseSearchPredicateCompatibleWebAreaElementService.swift; sourceTree = "<group>"; };
 		E27776E2240B780D00488320 /* LaunchAtLogin.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LaunchAtLogin.framework; path = Carthage/Build/Mac/LaunchAtLogin.framework; sourceTree = "<group>"; };
 		E27776E7240B784900488320 /* LaunchAtLogin.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = LaunchAtLogin.framework.dSYM; path = Carthage/Build/Mac/LaunchAtLogin.framework.dSYM; sourceTree = "<group>"; };
 		E279534A2494C534006D8D7A /* InputListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputListener.swift; sourceTree = "<group>"; };
@@ -278,7 +278,7 @@
 				E270F5C42504D8DE00AD305A /* TraverseElementServiceFinder.swift */,
 				E270F5C82504D9AE00AD305A /* TraverseGenericElementService.swift */,
 				E270F5CA2504D9DE00AD305A /* TraverseElementService.swift */,
-				E270F5CE2504DC4600AD305A /* TraverseWebAreaElementService.swift */,
+				E270F5CE2504DC4600AD305A /* TraverseSearchPredicateCompatibleWebAreaElementService.swift */,
 				E23140D52506781E004D1B96 /* QueryMenuBarItemsService.swift */,
 				E23140D725067A46004D1B96 /* QueryMenuBarExtrasService.swift */,
 				E23140D92507B2C1004D1B96 /* QueryNotificationCenterItemsService.swift */,
@@ -681,7 +681,7 @@
 				E267778C256123030034B131 /* String.swift in Sources */,
 				E261725A2324EC7100E396CA /* OverlayWindow.swift in Sources */,
 				E279535124962E8D006D8D7A /* ChunkyScroller.swift in Sources */,
-				E270F5CF2504DC4600AD305A /* TraverseWebAreaElementService.swift in Sources */,
+				E270F5CF2504DC4600AD305A /* TraverseSearchPredicateCompatibleWebAreaElementService.swift in Sources */,
 				E2795353249633DE006D8D7A /* Scroller.swift in Sources */,
 				E2C3221E23BC828C00508B44 /* HideCursorGlobally.m in Sources */,
 				E2B3F64B24F24B9800FD5594 /* HintModeInputListener.swift in Sources */,


### PR DESCRIPTION
Closes #270

Vimac uses accessibility element's action count to determine whether they are clickable/hintable.

Previously, Querying for web area elements leads to a lot of false-positives because non-clickable `<div>`s have actions, namely just two:

1. `AXShowMenu`
2. `AXScrollToVisible`

A heuristic to ignore these non-clickable divs is simply to ignore these two actions when retrieving the action count. This works, but there are occasionally clickable elements with just these two actions, leading to hints not shown for them (false-negatives).

The *real* problem is that we have no way to really know if an element is clickable, hence the need for this heuristic. Until now. Turns out you can, through search keys, specify the types of web elements you want to query for - not just all elements. This allows us to only ask for elements of types we are interested in showing hints for  (e.g. checkbox, button...).

