### PR TITLE
[Performance] Do not disable non-native AX flags on app that loses focus

### DIFF
--- a/ViMac-Swift/AppDelegate.swift
+++ b/ViMac-Swift/AppDelegate.swift
@@ -185,13 +185,7 @@ import Preferences
         _ = self.compositeDisposable.insert(
             frontmostAppChange.onlyWhen(isAXManualAccessibilityEnabled)
                 .observeOn(axWorker)
-                .subscribe(onNext: { (__previousApp, currentApp) in
-                    if let _previousApp = __previousApp {
-                        if let previousApp = _previousApp {
-                            AXManualAccessibilityActivator.deactivate(previousApp)
-                        }
-                    }
-
+                .subscribe(onNext: { (_, currentApp) in
                     if let currentApp = currentApp {
                         AXManualAccessibilityActivator.activate(currentApp)
                     }
@@ -214,13 +208,7 @@ import Preferences
         _ = self.compositeDisposable.insert(
             frontmostAppChange.onlyWhen(isAXEnhancedUserInterfaceEnabled)
                 .observeOn(axWorker)
-                .subscribe(onNext: { (__previousApp, currentApp) in
-                    if let _previousApp = __previousApp {
-                        if let previousApp = _previousApp {
-                            AXEnhancedUserInterfaceActivator.deactivate(previousApp)
-                        }
-                    }
-
+                .subscribe(onNext: { (_, currentApp) in
                     if let currentApp = currentApp {
                         AXEnhancedUserInterfaceActivator.activate(currentApp)
                     }


### PR DESCRIPTION
In v0.3.16, the non-native AX flags are set to disabled on applications that lose focus. 

I noticed when Alt-Tabing back to Chrome/VSCode that they freeze for a second because they have to set up all the AX related plumbing. This AX set up should be done as little as possible since it freezes the target app.