### PR TITLE
Added ability to use "gg" to scroll to top and "G" to scroll to bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ HJKL keys can be used to scroll within the scroll area.
 | Scroll right | l |
 | Scroll down by half the height of the scroll area | d |
 | Scroll up by half the height of the scroll area | u |
+| Scroll to top of page | gg |
+| Scroll to bottom of page | G |
 | Activate another scroll area | `Tab` |
 | Exit | `Escape` |
 

--- a/ViMac-Swift/ChunkyScroller.swift
+++ b/ViMac-Swift/ChunkyScroller.swift
@@ -57,6 +57,10 @@ class ChunkyScroller: Scroller {
                 yAxis = Int32(-sensitivity)
             case .up:
                 yAxis = Int32(sensitivity)
+            case .bottom:
+                yAxis = -Int32.max
+            case .top:
+                yAxis = Int32.max
             default:
                 fatalError("half-<direction> scroll directions should not used for smooth scrolling")
         }
@@ -64,12 +68,14 @@ class ChunkyScroller: Scroller {
         let isHorizontalScrollReversed = UserPreferences.ScrollMode.ReverseHorizontalScrollProperty.read()
         let isVerticalScrollReversed = UserPreferences.ScrollMode.ReverseVerticalScrollProperty.read()
         
-        if isHorizontalScrollReversed {
-            xAxis = -xAxis
-        }
-        
-        if isVerticalScrollReversed {
-            yAxis = -yAxis
+        if ![.bottom, .top].contains(direction) {
+            if isHorizontalScrollReversed {
+                xAxis = -xAxis
+            }
+            
+            if isVerticalScrollReversed {
+                yAxis = -yAxis
+            }
         }
         
         let frequency = 1.0 / 50.0

--- a/ViMac-Swift/Preferences/ScrollModePreferenceViewController.swift
+++ b/ViMac-Swift/Preferences/ScrollModePreferenceViewController.swift
@@ -44,7 +44,7 @@ final class ScrollModePreferenceViewController: NSViewController, NSTextFieldDel
         let scrollKeysRow: [NSView] = [scrollKeysLabel, scrollKeysField]
         grid.addRow(with: scrollKeysRow)
         
-        let scrollKeysHint1 = NSTextField(wrappingLabelWithString: "Format: {left}{down}{up}{right}{half-down}{half-up}{bottom}{top}")
+        let scrollKeysHint1 = NSTextField(wrappingLabelWithString: "Format: {left},{down},{up},{right},{half-down},{half-up},{bottom},{top}")
         scrollKeysHint1.font = .labelFont(ofSize: 11)
         scrollKeysHint1.textColor = .secondaryLabelColor
         grid.addRow(with: [NSGridCell.emptyContentView, scrollKeysHint1])

--- a/ViMac-Swift/Preferences/ScrollModePreferenceViewController.swift
+++ b/ViMac-Swift/Preferences/ScrollModePreferenceViewController.swift
@@ -44,7 +44,7 @@ final class ScrollModePreferenceViewController: NSViewController, NSTextFieldDel
         let scrollKeysRow: [NSView] = [scrollKeysLabel, scrollKeysField]
         grid.addRow(with: scrollKeysRow)
         
-        let scrollKeysHint1 = NSTextField(wrappingLabelWithString: "Format: {left}{down}{up}{right}{half-down}{half-up}")
+        let scrollKeysHint1 = NSTextField(wrappingLabelWithString: "Format: {left}{down}{up}{right}{half-down}{half-up}{bottom}{top}")
         scrollKeysHint1.font = .labelFont(ofSize: 11)
         scrollKeysHint1.textColor = .secondaryLabelColor
         grid.addRow(with: [NSGridCell.emptyContentView, scrollKeysHint1])
@@ -82,9 +82,7 @@ final class ScrollModePreferenceViewController: NSViewController, NSTextFieldDel
     }
     
     func isScrollKeysValid(keys: String) -> Bool {
-        let isCountValid = keys.count == 4 || keys.count == 6
-        let areKeysUnique = keys.count == Set(keys).count
-        return isCountValid && areKeysUnique
+        return UserPreferences.ScrollMode.ScrollKeysProperty.isValid(value: keys)
     }
 
     func onScrollKeysFieldEndEditing() {

--- a/ViMac-Swift/ScrollModeInputListener.swift
+++ b/ViMac-Swift/ScrollModeInputListener.swift
@@ -19,6 +19,8 @@ enum ScrollDirection {
     case halfDown
     case halfUp
     case halfRight
+    case top
+    case bottom
 }
 
 enum ScrollState {

--- a/ViMac-Swift/UserPreferences.swift
+++ b/ViMac-Swift/UserPreferences.swift
@@ -75,45 +75,50 @@ struct UserPreferences {
             typealias T = String
             
             static var key = "ScrollCharacters"
-            static var defaultValue = "hjkldu"
+            static var defaultValue = "h,j,k,l,d,u,G,gg"
             
             static func isValid(value keys: String) -> Bool {
-                let isCountValid = keys.count == 4 || keys.count == 6
-                let areKeysUnique = keys.count == Set(keys).count
-                return isCountValid && areKeysUnique
+                let keySequences = keys.components(separatedBy: ",")
+                let isCountValid = keySequences.count == 4 || keySequences.count == 6 || keySequences.count == 8
+                let areKeySequencesUnique = keySequences.count == Set(keySequences).count
+                return isCountValid && areKeySequencesUnique
             }
             
             static func readAsConfig() -> ScrollKeyConfig {
                 let s = read()
-                
-                let scrollLeftKey = s[s.index(s.startIndex, offsetBy: 0)]
-                let scrollDownKey = s[s.index(s.startIndex, offsetBy: 1)]
-                let scrollUpKey = s[s.index(s.startIndex, offsetBy: 2)]
-                let scrollRightKey = s[s.index(s.startIndex, offsetBy: 3)]
-                let scrollHalfDownKey = s.count == 6 ? (s[s.index(s.startIndex, offsetBy: 4)]) : nil
-                let scrollHalfUpKey = s.count == 6 ? (s[s.index(s.startIndex, offsetBy: 5)]) : nil
+                let keySequences = s.components(separatedBy: ",")
+                let scrollLeftKey = keySequences[0]
+                let scrollDownKey = keySequences[1]
+                let scrollUpKey = keySequences[2]
+                let scrollRightKey = keySequences[3]
+                let scrollHalfDownKey = keySequences.count >= 6 ? (keySequences[4]) : nil
+                let scrollHalfUpKey = keySequences.count >= 6 ? (keySequences[5]) : nil
+                let scrollBottomKey = keySequences[6]
+                let scrollTopKey = keySequences[7]
                 
                 var bindings: [ScrollKeyConfig.Binding] = [
-                    .init(keys: [scrollLeftKey], direction: .left),
-                    .init(keys: [scrollDownKey], direction: .down),
-                    .init(keys: [scrollUpKey], direction: .up),
-                    .init(keys: [scrollRightKey], direction: .right),
+                    .init(keys: Array(scrollLeftKey), direction: .left),
+                    .init(keys: Array(scrollDownKey), direction: .down),
+                    .init(keys: Array(scrollUpKey), direction: .up),
+                    .init(keys: Array(scrollRightKey), direction: .right),
+                    .init(keys: Array(scrollBottomKey), direction: .bottom),
+                    .init(keys: Array(scrollTopKey), direction: .top),
                     
-                    .init(keys: [Character(scrollLeftKey.uppercased())], direction: .halfLeft),
-                    .init(keys: [Character(scrollDownKey.uppercased())], direction: .halfDown),
-                    .init(keys: [Character(scrollUpKey.uppercased())], direction: .halfUp),
-                    .init(keys: [Character(scrollRightKey.uppercased())], direction: .halfRight),
+                    .init(keys: Array(scrollLeftKey.uppercased()), direction: .halfLeft),
+                    .init(keys: Array(scrollDownKey.uppercased()), direction: .halfDown),
+                    .init(keys: Array(scrollUpKey.uppercased()), direction: .halfUp),
+                    .init(keys: Array(scrollRightKey.uppercased()), direction: .halfRight),
                 ]
                 
                 if let k = scrollHalfDownKey {
                     bindings.append(
-                        .init(keys: [k], direction: .halfDown)
+                        .init(keys: Array(k), direction: .halfDown)
                     )
                 }
                 
                 if let k = scrollHalfUpKey {
                     bindings.append(
-                        .init(keys: [k], direction: .halfUp)
+                        .init(keys: Array(k), direction: .halfUp)
                     )
                 }
                 

--- a/ViMac-Swift/UserPreferences.swift
+++ b/ViMac-Swift/UserPreferences.swift
@@ -93,16 +93,14 @@ struct UserPreferences {
                 let scrollRightKey = keySequences[3]
                 let scrollHalfDownKey = keySequences.count >= 6 ? (keySequences[4]) : nil
                 let scrollHalfUpKey = keySequences.count >= 6 ? (keySequences[5]) : nil
-                let scrollBottomKey = keySequences[6]
-                let scrollTopKey = keySequences[7]
+                let scrollBottomKey = keySequences.count >= 8 ? keySequences[6] : nil
+                let scrollTopKey = keySequences.count >= 8 ? keySequences[7] : nil
                 
                 var bindings: [ScrollKeyConfig.Binding] = [
                     .init(keys: Array(scrollLeftKey), direction: .left),
                     .init(keys: Array(scrollDownKey), direction: .down),
                     .init(keys: Array(scrollUpKey), direction: .up),
                     .init(keys: Array(scrollRightKey), direction: .right),
-                    .init(keys: Array(scrollBottomKey), direction: .bottom),
-                    .init(keys: Array(scrollTopKey), direction: .top),
                     
                     .init(keys: Array(scrollLeftKey.uppercased()), direction: .halfLeft),
                     .init(keys: Array(scrollDownKey.uppercased()), direction: .halfDown),
@@ -119,6 +117,18 @@ struct UserPreferences {
                 if let k = scrollHalfUpKey {
                     bindings.append(
                         .init(keys: Array(k), direction: .halfUp)
+                    )
+                }
+                
+                if let k = scrollBottomKey {
+                    bindings.append(
+                        .init(keys: Array(k), direction: .bottom)
+                    )
+                }
+                
+                if let k = scrollTopKey {
+                    bindings.append(
+                        .init(keys: Array(k), direction: .top)
                     )
                 }
                 


### PR DESCRIPTION
Release Summary: Vimac can now recognize a sequence of scroll keys as a single action. More specifically, "gg" and "G" are now defaults for scrolling to the top and bottom of a scroll area.

This is a solution for issue #146 

Dev Summary:

* Vimac can now recognize a sequence of scroll keys as a single action.

* Scroll keys are delineated by a comma separated string to represent key sequences instead of just individual keys.

* Scroll key validation is now based on key sequences count instead of character count.

* Scrolling to top or bottom is done by scrolling by the max value of an Int32.

* Default waiting period for key sequences is 0.25 seconds before the input state is reset.

* "gg" and "G" are now defaults for scrolling to the top or bottom of a scroll area.