### PR TITLE
Ignore some AXActions; Fix isRowWithoutHintableChildren() implementation

### DIFF
--- a/ViMac-Swift/Accessibility/ElementTreeNode.swift
+++ b/ViMac-Swift/Accessibility/ElementTreeNode.swift
@@ -31,6 +31,8 @@ class ElementTreeNode {
         let ignoredActions: Set = [
             "AXShowMenu",
             "AXScrollToVisible",
+            "AXShowDefaultUI",
+            "AXShowAlternateUI"
         ]
         let actions = Set(root.actions).subtracting(ignoredActions)
         return actions.count > 0

--- a/ViMac-Swift/Accessibility/ElementTreeNode.swift
+++ b/ViMac-Swift/Accessibility/ElementTreeNode.swift
@@ -39,7 +39,7 @@ class ElementTreeNode {
     }
     
     private func isRowWithoutHintableChildren() -> Bool {
-        hintableChildrenCount() == 0 && root.role == "AXRow"
+         root.role == "AXRow" && hintableChildrenCount() == 0
     }
     
     private func hintableChildrenCount() -> Int {
@@ -54,10 +54,3 @@ class ElementTreeNode {
         return hintableChildrenCount
     }
 }
-
-class SafariWebAreaElementTreeNode : ElementTreeNode {
-    override func isHintable() -> Bool {
-        return true
-    }
-}
-

--- a/ViMac-Swift/Accessibility/ElementTreeNode.swift
+++ b/ViMac-Swift/Accessibility/ElementTreeNode.swift
@@ -46,7 +46,7 @@ class ElementTreeNode {
         }
         let children = self.children ?? []
         let hintableChildrenCount = children
-            .map { $0.hintableChildrenCount() }
+            .map { $0.hintableChildrenCount() + ($0.isHintable() ? 1 : 0) }
             .reduce(0, +)
         self.cachedHintableChildrenCount = hintableChildrenCount
         return hintableChildrenCount


### PR DESCRIPTION
The Finder sidebar's AXRows have these two actions which seem to do nothing, leading to overlapping hints with their direct pressable child:

![Screenshot 2021-03-30 at 3 00 34 PM](https://user-images.githubusercontent.com/34204380/112946915-affaaf00-9168-11eb-9c9d-2245720781e7.png)
