### PR TITLE
Ignore errors fetching actions when building Element

### DIFF
--- a/ViMac-Swift/Accessibility/Element.swift
+++ b/ViMac-Swift/Accessibility/Element.swift
@@ -30,9 +30,9 @@ class Element {
         guard let role: String = values[Attribute.role] as! String? else { return nil }
         let frame = NSRect(origin: position, size: size)
 
-        guard let actions = try? uiElement.actionsAsStrings() else { return nil }
+        let actions = try? uiElement.actionsAsStrings()
         
-        return Element.init(rawElement: rawElement, frame: frame, actions: actions, role: role)
+        return Element.init(rawElement: rawElement, frame: frame, actions: actions ?? [], role: role)
     }
     
     init(rawElement: AXUIElement, frame: NSRect, actions: [String], role: String) {


### PR DESCRIPTION
I notice that hints were not shown for these items in the App Store because their ancestor element's actions cannot be fetched (`kAXFailure`). Since that operation fails, Vimac doesn't query that ancestor element's children.

<img width="880" alt="Screenshot 2021-03-31 at 4 37 00 PM" src="https://user-images.githubusercontent.com/34204380/113115733-51eccb00-923f-11eb-9d7e-6e5067631780.png">

Unlike the other three attributes, actions are not "compulsory" attributes of an Element. Making the success of the action optional should allow for more hints in shoddy AX implementations.

Also, I should probably be developing tools to make debugging these issues easier.

End result:
<img width="979" alt="Screenshot 2021-03-31 at 4 41 22 PM" src="https://user-images.githubusercontent.com/34204380/113116356-f0792c00-923f-11eb-8858-d024a80dd90e.png">
