### PR TITLE
Revert "Use AXUIElementCopyAttributeValues to fetch an element's chil…

### DIFF
--- a/ViMac-Swift/Accessibility/HintMode/TraverseGenericElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseGenericElementService.swift
@@ -65,13 +65,12 @@ class TraverseGenericElementService : TraverseElementService {
     }
 
     private func getChildren(_ element: Element) throws -> [Element]? {
-        let uiElements: [UIElement]? = try {
+        let rawElements: [AXUIElement]? = try {
             if element.role == "AXTable" || element.role == "AXOutline" {
-                return try UIElement(element.rawElement).valuesForAttribute(.visibleRows, startAtIndex: 0, maxValues: 999)
+                return try UIElement(element.rawElement).attribute(.visibleRows)
             }
-            return try UIElement(element.rawElement).valuesForAttribute(.children, startAtIndex: 0, maxValues: 999)
+            return try UIElement(element.rawElement).attribute(.children)
         }()
-        let rawElements = uiElements?.map { $0.element }
         return rawElements?
             .map { Element.initialize(rawElement: $0) }
             .compactMap({ $0 })


### PR DESCRIPTION
…dren"

This reverts commit 57f0dc6e9db28573f104ab842d7461ac4f461640.

This change made Books.app more hintable but App Store less hintable. I think better tooling has to be set up and automated testing should be done before making AX/Hinting changes like this.