### PR TITLE
Save preferences text field changes without needing to hit Enter

### DIFF
--- a/ViMac-Swift/Bindings/BindingsPreferenceViewController.swift
+++ b/ViMac-Swift/Bindings/BindingsPreferenceViewController.swift
@@ -170,38 +170,52 @@ class BindingsPreferenceViewController: NSViewController, PreferencePane, NSText
         UserDefaultsProperties.keySequenceScrollModeEnabled.write(enabled)
     }
     
-    private func onHintModeKeySequenceTextFieldEndEditing() {
+    private func onHintModeKeySequenceTextFieldChange() {
         let value = hintModeKeySequenceTextField.stringValue
         UserDefaultsProperties.keySequenceHintMode.write(value)
     }
     
-    private func onScrollModeKeySequenceTextFieldEndEditing() {
+    private func onScrollModeKeySequenceTextFieldChange() {
         let value = scrollModeKeySequenceTextField.stringValue
         UserDefaultsProperties.keySequenceScrollMode.write(value)
     }
     
+    private func onResetDelayTextFieldChange() {
+        let valueString = resetDelayTextField.stringValue
+        UserDefaultsProperties.keySequenceResetDelay.write(valueString)
+    }
+    
     private func onResetDelayTextFieldEndEditing() {
         let valueString = resetDelayTextField.stringValue
-        guard let value = Double(valueString) else {
+        if valueString.count > 0 && Double(valueString) == nil {
             showInvalidValueDialog(valueString)
             return
         }
-
-        UserDefaultsProperties.keySequenceResetDelay.write(value)
     }
-    
-    func controlTextDidEndEditing(_ notification: Notification) {
+
+    func controlTextDidChange(_ notification: Notification) {
         guard let textField = notification.object as? NSTextField else {
             return
         }
         
         if textField == hintModeKeySequenceTextField {
-            onHintModeKeySequenceTextFieldEndEditing()
+            onHintModeKeySequenceTextFieldChange()
             return
         }
 
         if textField == scrollModeKeySequenceTextField {
-            onScrollModeKeySequenceTextFieldEndEditing()
+            onScrollModeKeySequenceTextFieldChange()
+            return
+        }
+        
+        if textField == resetDelayTextField {
+            onResetDelayTextFieldChange()
+            return
+        }
+    }
+    
+    func controlTextDidEndEditing(_ notification: Notification) {
+        guard let textField = notification.object as? NSTextField else {
             return
         }
         

--- a/ViMac-Swift/Bindings/BindingsRepository.swift
+++ b/ViMac-Swift/Bindings/BindingsRepository.swift
@@ -16,7 +16,7 @@ class BindingsRepository {
             hintModeKeySequence: UserDefaultsProperties.keySequenceHintMode.read(),
             scrollModeKeySequenceEnabled: UserDefaultsProperties.keySequenceScrollModeEnabled.read(),
             scrollModeKeySequence: UserDefaultsProperties.keySequenceScrollMode.read(),
-            resetDelay: UserDefaultsProperties.keySequenceResetDelay.read()
+            resetDelay: Double(UserDefaultsProperties.keySequenceResetDelay.read()) ?? Double(UserDefaultsProperties.keySequenceResetDelay.defaultValue)!
         )
     }
     

--- a/ViMac-Swift/Preferences/HintModePreferenceViewController.swift
+++ b/ViMac-Swift/Preferences/HintModePreferenceViewController.swift
@@ -38,6 +38,7 @@ final class HintModePreferenceViewController: NSViewController, NSTextFieldDeleg
         customCharactersField = NSTextField()
         customCharactersField.delegate = self
         customCharactersField.stringValue = UserPreferences.HintMode.CustomCharactersProperty.readUnvalidated() ?? ""
+        customCharactersField.placeholderString = UserPreferences.HintMode.CustomCharactersProperty.defaultValue
         let customCharactersRow: [NSView] = [customCharactersLabel, customCharactersField]
         grid.addRow(with: customCharactersRow)
         
@@ -71,14 +72,17 @@ final class HintModePreferenceViewController: NSViewController, NSTextFieldDeleg
         ])
     }
     
+    func onCustomCharactersFieldChange() {
+        let value = customCharactersField.stringValue
+        UserPreferences.HintMode.CustomCharactersProperty.save(value: value)
+    }
+    
     func onCustomCharactersFieldEndEditing() {
         let value = customCharactersField.stringValue
         let isValid = UserPreferences.HintMode.CustomCharactersProperty.isValid(value: value)
         
         if value.count > 0 && !isValid {
             showInvalidValueDialog(value)
-        } else {
-            UserPreferences.HintMode.CustomCharactersProperty.save(value: value)
         }
     }
     
@@ -88,8 +92,27 @@ final class HintModePreferenceViewController: NSViewController, NSTextFieldDeleg
 
         if value.count > 0 && !isValid {
             showInvalidValueDialog(value)
-        } else {
-            UserPreferences.HintMode.TextSizeProperty.save(value: value)
+        }
+    }
+    
+    func onTextSizeFieldChange() {
+        let value = textSizeField.stringValue
+        UserPreferences.HintMode.TextSizeProperty.save(value: value)
+    }
+    
+    func controlTextDidChange(_ notification: Notification) {
+        guard let textField = notification.object as? NSTextField else {
+            return
+        }
+        
+        if textField == customCharactersField {
+            onCustomCharactersFieldChange()
+            return
+        }
+
+        if textField == textSizeField {
+            onTextSizeFieldChange()
+            return
         }
     }
     

--- a/ViMac-Swift/Preferences/ScrollModePreferenceViewController.swift
+++ b/ViMac-Swift/Preferences/ScrollModePreferenceViewController.swift
@@ -84,6 +84,11 @@ final class ScrollModePreferenceViewController: NSViewController, NSTextFieldDel
     func isScrollKeysValid(keys: String) -> Bool {
         return UserPreferences.ScrollMode.ScrollKeysProperty.isValid(value: keys)
     }
+    
+    func onScrollKeysFieldChange() {
+        let value = scrollKeysField.stringValue
+        UserPreferences.ScrollMode.ScrollKeysProperty.save(value: value)
+    }
 
     func onScrollKeysFieldEndEditing() {
         let value = scrollKeysField.stringValue
@@ -91,8 +96,6 @@ final class ScrollModePreferenceViewController: NSViewController, NSTextFieldDel
         
         if value.count > 0 && !isValid {
             showInvalidValueDialog(value)
-        } else {
-            UserPreferences.ScrollMode.ScrollKeysProperty.save(value: value)
         }
     }
     
@@ -114,6 +117,17 @@ final class ScrollModePreferenceViewController: NSViewController, NSTextFieldDel
     @objc func onRevVerticalScrollEdit() {
         let value = revVerticalScrollView.state == .on
         UserPreferences.ScrollMode.ReverseVerticalScrollProperty.save(value: value)
+    }
+    
+    func controlTextDidChange(_ notification: Notification) {
+        guard let textField = notification.object as? NSTextField else {
+            return
+        }
+        
+        if textField == scrollKeysField {
+            onScrollKeysFieldChange()
+            return
+        }
     }
     
     func controlTextDidEndEditing(_ notification: Notification) {

--- a/ViMac-Swift/UserDefaults/UserDefaultsProperties.swift
+++ b/ViMac-Swift/UserDefaults/UserDefaultsProperties.swift
@@ -13,7 +13,7 @@ struct UserDefaultsProperties {
     static let keySequenceHintMode = UserDefaultsProperty<String>.init("keySequenceHintMode", defaultValue: "")
     static let keySequenceScrollModeEnabled = UserDefaultsProperty<Bool>.init("keySequenceScrollModeEnabled", defaultValue: false)
     static let keySequenceScrollMode = UserDefaultsProperty<String>.init("keySequenceScrollMode", defaultValue: "")
-    static let keySequenceResetDelay = UserDefaultsProperty<TimeInterval>.init("keySequenceResetDelay", defaultValue: 0.25)
+    static let keySequenceResetDelay = UserDefaultsProperty<String>.init("keySequenceResetDelay", defaultValue: "0.25")
     
     static let AXEnhancedUserInterfaceEnabled = UserDefaultsProperty<Bool>.init("AXEnhancedUserInterfaceEnabled", defaultValue: false)
     static let AXManualAccessibilityEnabled = UserDefaultsProperty<Bool>.init("AXManualAccessibilityEnabled", defaultValue: false)


### PR DESCRIPTION
Currently If someone edits a text field and then `Command-Tab` away to test out the configuration, the changes will not be applied until they hit Enter or change to another text field.

This PR saves the changes as the user types.