### PR TITLE
Control + [ can now be used to escape scroll mode. Patched bug with scroll to bottom.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Simply type the assigned "hint-text" (eg. "sa") to perform a click at the locati
 | Double left click | Type the assigned hint-text while holding `Command` |
 | Move cursor | Type the assigned hint-text while holding `Option` |
 | Rotate hints | `Space` |
-| Exit | `Escape` |
+| Exit | `Escape` or `Control + [`|
 
 Tip(s):
 - After executing a right-click action, use `Control-N` and `Control-P` to select the next and previous context menu item respectively.
@@ -65,7 +65,7 @@ HJKL keys can be used to scroll within the scroll area.
 | Scroll to top of page | gg |
 | Scroll to bottom of page | G |
 | Activate another scroll area | `Tab` |
-| Exit | `Escape` |
+| Exit | `Escape` or `Control + [`|
 
 You can also scroll up/down/left/right by half a page by holding `Shift` when pressing the `hjkl` keys.
 

--- a/ViMac-Swift/ChunkyScroller.swift
+++ b/ViMac-Swift/ChunkyScroller.swift
@@ -58,9 +58,11 @@ class ChunkyScroller: Scroller {
             case .up:
                 yAxis = Int32(sensitivity)
             case .bottom:
-                yAxis = -Int32.max
+                yAxis = Int32(Int16.min)
             case .top:
-                yAxis = Int32.max
+                // Some applications (VS Code) have issues using Int32.max to scroll. Instead of scrolling to the top, they scroll to the bottom.
+                // Not sure what causes this.
+                yAxis = Int32(Int16.max)
             default:
                 fatalError("half-<direction> scroll directions should not used for smooth scrolling")
         }
@@ -68,6 +70,7 @@ class ChunkyScroller: Scroller {
         let isHorizontalScrollReversed = UserPreferences.ScrollMode.ReverseHorizontalScrollProperty.read()
         let isVerticalScrollReversed = UserPreferences.ScrollMode.ReverseVerticalScrollProperty.read()
         
+        var frequency: Double
         if ![.bottom, .top].contains(direction) {
             if isHorizontalScrollReversed {
                 xAxis = -xAxis
@@ -76,9 +79,12 @@ class ChunkyScroller: Scroller {
             if isVerticalScrollReversed {
                 yAxis = -yAxis
             }
+            
+            frequency = 1.0 / 50.0
         }
-        
-        let frequency = 1.0 / 50.0
+        else {
+            frequency = 0.25
+        }
         
         return ChunkyScroller(frequency: frequency, xAxis: xAxis, yAxis: yAxis)
     }

--- a/ViMac-Swift/Modes/HintModeController.swift
+++ b/ViMac-Swift/Modes/HintModeController.swift
@@ -37,7 +37,11 @@ enum HintModeInputIntent {
 
     static func from(event: NSEvent) -> HintModeInputIntent? {
         if event.type != .keyDown { return nil }
-        if event.keyCode == kVK_Escape { return .exit }
+        if event.keyCode == kVK_Escape ||
+            (event.keyCode == kVK_ANSI_LeftBracket &&
+                event.modifierFlags.rawValue & NSEvent.ModifierFlags.control.rawValue == NSEvent.ModifierFlags.control.rawValue) {
+            return .exit
+        }
         if event.keyCode == kVK_Delete { return .backspace }
         if event.keyCode == kVK_Space { return .rotate }
 

--- a/ViMac-Swift/ScrollModeInputListener.swift
+++ b/ViMac-Swift/ScrollModeInputListener.swift
@@ -41,6 +41,7 @@ class ScrollModeInputListener {
     
     let scrollEventSubject: PublishSubject<ScrollEvent> = PublishSubject()
     let escapeEventSubject: PublishSubject<Void> = PublishSubject()
+    let controlLeftBracketEventSubject: PublishSubject<Void> = PublishSubject()
     let tabEventSubject: PublishSubject<Void> = PublishSubject()
     
     init(scrollKeyConfig: ScrollKeyConfig, inputListener: InputListener) {
@@ -49,6 +50,7 @@ class ScrollModeInputListener {
 
         disposeBag.insert(observeScrollEvent(bindings: scrollKeyConfig.bindings))
         disposeBag.insert(observeEscapeKey())
+        disposeBag.insert(observeControlLeftBracketKeyCombo())
         disposeBag.insert(observeTabKey())
     }
     
@@ -70,6 +72,17 @@ class ScrollModeInputListener {
         })
         return escapeEvents.bind(onNext: { [weak self] _ in
             self!.escapeEventSubject.onNext(())
+        })
+    }
+    
+    func observeControlLeftBracketKeyCombo() -> Disposable {
+        let controlLeftBracketEvents = events().filter({ event in
+            event.keyCode == kVK_ANSI_LeftBracket &&
+                event.type == .keyDown &&
+                event.modifierFlags.rawValue & NSEvent.ModifierFlags.control.rawValue == NSEvent.ModifierFlags.control.rawValue
+        })
+        return controlLeftBracketEvents.bind(onNext: { [weak self] _ in
+            self!.controlLeftBracketEventSubject.onNext(())
         })
     }
     

--- a/ViMac-Swift/ViewControllers/ScrollModeViewController.swift
+++ b/ViMac-Swift/ViewControllers/ScrollModeViewController.swift
@@ -29,6 +29,7 @@ class ScrollModeViewController: ModeViewController {
     override func viewWillAppear() {
         observeScrollAreas().disposed(by: disposeBag)
         observeEscKey().disposed(by: disposeBag)
+        observeControlLeftBracketKeyCombo().disposed(by: disposeBag)
     }
 
     private func setActiveState(scrollAreas: [Element]) {
@@ -65,7 +66,19 @@ class ScrollModeViewController: ModeViewController {
         let escEvents = inputListener.keyDownEvents.filter { $0.keyCode == kVK_Escape }
         return escEvents
             .bind(onNext: { [weak self] _ in
-                Analytics.shared().track("Scroll Mode Deactivated")
+                Analytics.shared().track("Scroll Mode Deactivated with Escape")
+                self?.delegate?.deactivate()
+            })
+    }
+    
+    private func observeControlLeftBracketKeyCombo() -> Disposable {
+        let controlLeftBracketEvents = inputListener.keyDownEvents.filter {
+            $0.keyCode == kVK_ANSI_LeftBracket &&
+            $0.modifierFlags.rawValue & NSEvent.ModifierFlags.control.rawValue == NSEvent.ModifierFlags.control.rawValue
+        }
+        return controlLeftBracketEvents
+            .bind(onNext: { [weak self] _ in
+                Analytics.shared().track("Scroll Mode Deactivated with Control + [")
                 self?.delegate?.deactivate()
             })
     }


### PR DESCRIPTION
* Control + [ can now be used to escape scroll mode. Along with Escape, this is a standard way to exit modes in Vim. 
* Patched a bug with scroll top. Some applications (VS Code) have issues using Int32.max to scroll. Instead of scrolling to the top, they scroll to the bottom. Not sure what causes this.