### PR TITLE
Fix for #373. AXLink hints are now placed near the bottom left corner of the AXLink…

### DIFF
--- a/ViMac-Swift/AppDelegate.swift
+++ b/ViMac-Swift/AppDelegate.swift
@@ -310,7 +310,7 @@ extension AppDelegate : NSWindowDelegate {
             "Non Native Support Enabled": UserDefaultsProperties.AXEnhancedUserInterfaceEnabled.read(),
             "Electron Support Enabled": UserDefaultsProperties.AXManualAccessibilityEnabled.read()
         ])
-        
+            
         let transformState = ProcessApplicationTransformState(kProcessTransformToUIElementApplication)
         var psn = ProcessSerialNumber(highLongOfPSN: 0, lowLongOfPSN: UInt32(kCurrentProcess))
         TransformProcessType(&psn, transformState)

--- a/ViMac-Swift/GeometryUtils.swift
+++ b/ViMac-Swift/GeometryUtils.swift
@@ -16,6 +16,44 @@ class GeometryUtils {
         )
     }
     
+    static func corner(_ frame: NSRect, top: Bool, right: Bool, offset: CGFloat) -> NSPoint {
+        var x = CGFloat(0)
+        var y = CGFloat(0)
+        
+        var xOffset = CGFloat(0)
+        var yOffset = CGFloat(0)
+        
+        if offset < frame.width {
+            xOffset = offset
+        }
+        else {
+            xOffset = CGFloat(0)
+        }
+        
+        if offset < frame.height {
+            yOffset = offset
+        }
+        else {
+            yOffset = CGFloat(0)
+        }
+        
+        if right {
+            x = frame.maxX - xOffset
+        }
+        else {
+            x = frame.origin.x + xOffset
+        }
+        
+        if top {
+            y = frame.maxY - yOffset
+        }
+        else {
+            y = frame.origin.y + yOffset
+        }
+        
+        return NSPoint(x: x, y: y)
+    }
+    
     static func convertGlobalFrame(_ globalFrame: NSRect, relativeTo: NSPoint) -> NSRect {
         let menuBarScreen = NSScreen.screens.first!
         

--- a/ViMac-Swift/Modes/HintModeController.swift
+++ b/ViMac-Swift/Modes/HintModeController.swift
@@ -313,26 +313,30 @@ class HintModeController: ModeController {
     
     private func performHintAction(_ hint: Hint, action: HintAction) {
         let element = hint.element
+        let clickPosition: NSPoint = {
+            // hints are shown at the bottom-left for AXLinks (see HintsViewController#renderHint),
+            // so a click is performed there
+            if element.role == "AXLink" {
+                return NSPoint(
+                    // tiny offset in case clicking on the edge of the element does nothing
+                    x: element.frame.origin.x + 5,
+                    y: element.frame.origin.y + element.frame.height - 5
+                )
+            }
+            return GeometryUtils.center(element.frame)
+        }()
 
-        let frame = element.clippedFrame ?? element.frame
-        let position = frame.origin
-        let size = frame.size
-
-        let centerPositionX = position.x + (size.width / 2)
-        let centerPositionY = position.y + (size.height / 2)
-        let centerPosition = NSPoint(x: centerPositionX, y: centerPositionY)
-
-        Utils.moveMouse(position: centerPosition)
+        Utils.moveMouse(position: clickPosition)
 
         switch action {
         case .leftClick:
-            Utils.leftClickMouse(position: centerPosition)
+            Utils.leftClickMouse(position: clickPosition)
         case .rightClick:
-            Utils.rightClickMouse(position: centerPosition)
+            Utils.rightClickMouse(position: clickPosition)
         case .doubleLeftClick:
-            Utils.doubleLeftClickMouse(position: centerPosition)
+            Utils.doubleLeftClickMouse(position: clickPosition)
         case .move:
-            Utils.moveMouse(position: centerPosition)
+            Utils.moveMouse(position: clickPosition)
         }
     }
     

--- a/ViMac-Swift/Modes/HintsViewController.swift
+++ b/ViMac-Swift/Modes/HintsViewController.swift
@@ -66,7 +66,9 @@ class HintsViewController: NSViewController {
         }
         self.hintViews = shuffledHintViews
     }
-    
+
+    // are you changing the location where hints are rendered?
+    // make sure to update HintModeController#performHintAction as well
     func renderHint(_ hint: Hint) -> HintView? {
         let view = HintView(associatedElement: hint.element, hintTextSize: CGFloat(textSize), hintText: hint.text, typedHintText: "")
         guard let elementFrame = self.elementFrame(hint.element) else { return nil }

--- a/ViMac-Swift/Modes/HintsViewController.swift
+++ b/ViMac-Swift/Modes/HintsViewController.swift
@@ -70,7 +70,15 @@ class HintsViewController: NSViewController {
     func renderHint(_ hint: Hint) -> HintView? {
         let view = HintView(associatedElement: hint.element, hintTextSize: CGFloat(textSize), hintText: hint.text, typedHintText: "")
         guard let elementFrame = self.elementFrame(hint.element) else { return nil }
-        let elementCenter: NSPoint = GeometryUtils.center(elementFrame)
+        
+        var elementCenter: NSPoint
+        if hint.element.role == "AXLink" {
+            // It's likely that the hint text size chosen by the user is roughly equivalent to their viewing text size, hence textSize being used as the offset.
+            elementCenter = GeometryUtils.corner(elementFrame, top: false, right: false, offset: CGFloat(textSize))
+        }
+        else {
+            elementCenter = GeometryUtils.center(elementFrame)
+        }
 
         let hintOrigin = NSPoint(
             x: elementCenter.x - (view.intrinsicContentSize.width / 2),

--- a/ViMac-Swift/Modes/HintsViewController.swift
+++ b/ViMac-Swift/Modes/HintsViewController.swift
@@ -71,19 +71,19 @@ class HintsViewController: NSViewController {
         let view = HintView(associatedElement: hint.element, hintTextSize: CGFloat(textSize), hintText: hint.text, typedHintText: "")
         guard let elementFrame = self.elementFrame(hint.element) else { return nil }
         
-        var elementCenter: NSPoint
-        if hint.element.role == "AXLink" {
-            // It's likely that the hint text size chosen by the user is roughly equivalent to their viewing text size, hence textSize being used as the offset.
-            elementCenter = GeometryUtils.corner(elementFrame, top: false, right: false, offset: CGFloat(textSize))
-        }
-        else {
-            elementCenter = GeometryUtils.center(elementFrame)
-        }
-
-        let hintOrigin = NSPoint(
-            x: elementCenter.x - (view.intrinsicContentSize.width / 2),
-            y: elementCenter.y - (view.intrinsicContentSize.height / 2)
-        )
+        let hintOrigin: NSPoint = {
+            // position hint on bottom-left of AXLinks (see #373)
+            if hint.element.role == "AXLink" {
+                return elementFrame.origin
+            }
+            
+            // position hint on center of element
+            let elementCenter = GeometryUtils.center(elementFrame)
+            return NSPoint(
+                x: elementCenter.x - (view.intrinsicContentSize.width / 2),
+                y: elementCenter.y - (view.intrinsicContentSize.height / 2)
+            )
+        }()
 
         if hintOrigin.x.isNaN || hintOrigin.y.isNaN {
             return nil


### PR DESCRIPTION
… frame instead of in the middle. Placing the hint in the middle leads to unclickable links when the link wraps only once (see #373).

The hint text size acts as the offset from the corner since it's likely the viewers choice of hint text size correlates to their text viewing size. This means that most of the time the hint will be placed at the beginning of the last line wrap of the link.