### PR TITLE
Do not show Accessibility prompt until Grant Permission button is cli…

### DIFF
--- a/ViMac-Swift/AppDelegate.swift
+++ b/ViMac-Swift/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var compositeDisposable: CompositeDisposable
     var scrollModeDisposable: CompositeDisposable? = CompositeDisposable()
     
-    let modeCoordinator: ModeCoordinator
+    var modeCoordinator: ModeCoordinator!
     let overlayWindowController: OverlayWindowController
     var preferencesWindowController: PreferencesWindowController!
     var statusItemManager: StatusItemManager!
@@ -36,12 +36,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let frontmostAppService = FrontmostApplicationService.init()
     
     override init() {
-        
-        UIElement.globalMessagingTimeout = 1
-        
         InputSourceManager.initialize()
         overlayWindowController = OverlayWindowController()
-        modeCoordinator = ModeCoordinator()
         
         LaunchAtLogin.isEnabled = UserDefaults.standard.bool(forKey: Utils.shouldLaunchOnStartupKey)
         KeyboardShortcuts.shared.registerDefaults()
@@ -83,7 +79,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func onAXPermissionGranted() {
         closePermissionRequestingWindow()
         
+        UIElement.globalMessagingTimeout = 1
+        
         self.checkForUpdatesInBackground()
+        self.modeCoordinator = ModeCoordinator()
         self.setupWindowEventAndShortcutObservables()
         self.setupAXAttributeObservables()
     }


### PR DESCRIPTION
…cked

ModeCoordinator sets up CGEventTap for to listen for key sequences. I thought this only requires input monitoring permission, but it also requires AX permissions. Creating the event tap causes the prompt to show up. ModeCoordinator is now init-ed after AX permissions is granted.

![Screenshot 2021-04-19 at 4 55 38 PM](https://user-images.githubusercontent.com/34204380/115209458-33883a00-a130-11eb-9ab2-051f515de889.png)
