### PR TITLE
Do not allow one character long key sequence

### DIFF
--- a/ViMac-Swift/VimacKeySequenceListener.swift
+++ b/ViMac-Swift/VimacKeySequenceListener.swift
@@ -96,10 +96,10 @@ class VimacKeySequenceListener {
     
     func createKeySequenceListener(config: BindingsConfig) -> KeySequenceListener? {
         var sequences: [[Character]] = []
-        if config.hintModeKeySequenceEnabled {
+        if config.hintModeKeySequenceEnabled && config.hintModeKeySequence.count > 1 {
             sequences.append(Array(config.hintModeKeySequence))
         }
-        if config.scrollModeKeySequenceEnabled {
+        if config.scrollModeKeySequenceEnabled && config.scrollModeKeySequence.count > 1 {
             sequences.append(Array(config.scrollModeKeySequence))
         }
         


### PR DESCRIPTION
One character long keys prevents you from typing the key. A problem I realized was that you can't register "aa" without copy-pasting it in.