### PR TITLE
Do not cast CGEvent to NSEvent if type is disabled

### DIFF
--- a/ViMac-Swift/KeySequenceListener.swift
+++ b/ViMac-Swift/KeySequenceListener.swift
@@ -71,6 +71,11 @@ class KeySequenceListener {
     }
     
     private func onEvent(event: CGEvent) -> CGEvent? {
+        // crashes if you attempt to cast it to NSEvent
+        if event.type == .tapDisabledByTimeout || event.type == .tapDisabledByUserInput {
+            return event
+        }
+        
         guard let nsEvent = NSEvent(cgEvent: event) else {
             resetInput()
             return event


### PR DESCRIPTION
Closes #355 

Casting cgevent's disabled event crashes the application. Vimac didn't crash because the key seq code was running in a different thread.

```
2021-04-20 16:33:12.003174+0800 Vimac[83948:2685523] unrecognized type is 4294967294
2021-04-20 16:33:12.003313+0800 Vimac[83948:2685523] *** Assertion failure in -[NSEvent _initWithCGEvent:eventRef:], NSEvent.m:1942
2021-04-20 16:33:12.003709+0800 Vimac[83948:2685523] [General] Invalid parameter not satisfying: _type > 0 && _type <= kCGSLastEventType
2021-04-20 16:33:12.007296+0800 Vimac[83948:2685523] [General] (
	0   CoreFoundation                      0x00007fff207a66af __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007fff204de3c9 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff207cf512 +[NSException raise:format:arguments:] + 88
	3   Foundation                          0x00007fff2158b6c9 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 191
	4   AppKit                              0x00007fff230d1973 -[NSEvent _initWithCGEvent:eventRef:] + 2920
	5   AppKit                              0x00007fff23271b1d +[NSEvent eventWithCGEvent:] + 104
	6   Vimac                               0x000000010c2cba27 $sSo7NSEventC7cgEventABSgSo10CGEventRefa_tcfCTO + 39
	7   Vimac                               0x000000010c2c977b $s5Vimac19KeySequenceListenerC7onEvent33_30A1D2675CF473682185B4714D0C5DA9LL5eventSo10CGEventRefaSgAH_tF + 779
	8   Vimac                               0x000000010c2c936f $s5Vimac19KeySequenceListenerC5startyyFSo10CGEventRefaSgAFcfU_ + 239
	9   Vimac                               0x000000010c2bde2c 
```