### PR TITLE
Older Chromium/Electron app support - Multi-shot with single search key

### DIFF
--- a/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
+++ b/ViMac-Swift/Accessibility/HintMode/TraverseSearchPredicateCompatibleWebAreaElementService.swift
@@ -67,6 +67,11 @@ class TraverseSearchPredicateCompatibleWebAreaElementService : TraverseElementSe
         return element.frame
     }
     
+    // use search predicates to query for web area children elements
+    // Note: There is a difference in implementation of search keys for Chromium and WebKit,
+    // hence the need to have different approaches "one-shot with all search keys" (WebKit) vs "multiple-shots with a single search key" (Chromium)
+    // Chromium has fixed their implementation to act like WebKit, but current versions (~90.0) need this workaround.
+    // https://chromium-review.googlesource.com/c/chromium/src/+/2773520
     private func getRecursiveChildrenThroughSearchPredicate() throws -> [Element]? {
         let queryAnySearchKey: [String: Any] = [
             "AXDirection": "AXDirectionNext",


### PR DESCRIPTION
Previously, only Safari apps are using search keys. Other web areas used the "any" search key which leads to a bunch of non-clickable hints shown.

This is because there is a difference in implementation of search keys for Chromium and WebKit (OR vs AND). See the patch [1].

Hence, to use search keys, there is a need to have different approaches "one-shot with all search keys" (WebKit) vs "multiple-shots with a single search key" (Chromium)

Chromium has fixed their implementation to act like WebKit [1], but current versions (~90.0) need this workaround.

[1] https://chromium-review.googlesource.com/c/chromium/src/+/2773520