### PR TITLE
Include Core Graphics header file

### DIFF
--- a/ViMac-Swift/HideCursorGlobally.m
+++ b/ViMac-Swift/HideCursorGlobally.m
@@ -7,6 +7,7 @@
 //
 
 #import "HideCursorGlobally.h"
+#import "CoreGraphics/CoreGraphics.h"
 
 @implementation HideCursorGlobally
 


### PR DESCRIPTION
Fixes compilation error by including Core Graphics header file.

https://github.com/dexterleng/vimac/issues/464